### PR TITLE
Fix TypeError in mujoco UR5e toolbox.

### DIFF
--- a/robo_manip_baselines/envs/mujoco/ur5e/MujocoUR5eToolboxEnv.py
+++ b/robo_manip_baselines/envs/mujoco/ur5e/MujocoUR5eToolboxEnv.py
@@ -30,20 +30,20 @@ class MujocoUR5eToolboxEnv(MujocoUR5eEnvBase):
             **kwargs,
         )
 
-        # self.original_toolbox_pos = self.model.body("toolbox").pos.copy()
-        # self.toolbox_pos_offsets = np.array(
-        #     [
-        #         [0.0, -0.06, 0.0],
-        #         [0.0, -0.03, 0.0],
-        #         [0.0, 0.0, 0.0],
-        #         [0.0, 0.03, 0.0],
-        #         [0.0, 0.06, 0.0],
-        #         [0.0, 0.09, 0.0],
-        #     ]
-        # )  # [m]
+        self.original_toolbox_pos = self.model.body("toolbox").pos.copy()
+        self.toolbox_pos_offsets = np.array(
+            [
+                [0.0, -0.06, 0.0],
+                [0.0, -0.03, 0.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.03, 0.0],
+                [0.0, 0.06, 0.0],
+                [0.0, 0.09, 0.0],
+            ]
+        )  # [m]
 
     def modify_world(self, world_idx=None, cumulative_idx=None):
-        # if world_idx is None:
-        #     world_idx = cumulative_idx % len(self.toolbox_pos_offsets)
+        if world_idx is None:
+            world_idx = cumulative_idx % len(self.toolbox_pos_offsets)
 
         return world_idx


### PR DESCRIPTION
`Teleop.py MujocoUR5eToolbox` を引数 `world_idx_list` なしで実行すると、成功データを.rmbで保存する際に`TypeError`になる不具合への対処です。

head_repository の別ブランチ(`Fix-Toolbox-Idea1`)に別内容の修正案があります。